### PR TITLE
Refactor AMD pm rules to remove handwritten bool alu

### DIFF
--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -156,6 +156,34 @@ class TestBFloat16(unittest.TestCase):
     assert t.dtype == dtypes.bfloat16
     np.testing.assert_allclose(t.numpy(), np.eye(3))
 
+  def test_bf16_less_than(self):
+      t1 = Tensor([100, -1, 0, -100, 20, 100, -1, 0, -100, 20]).cast(dtypes.bfloat16)
+      t2 = Tensor([101, 0, 1, -99, 21, 99, -2, -1, -101, 19]).cast(dtypes.bfloat16)
+      t1.realize()
+      t2.realize()
+      assert (t1 < t2).numpy().tolist() == [True, True, True, True, True, False, False, False, False, False]
+
+  def test_bf16_not_equal(self):
+      t1 = Tensor([100, -1, -10, -100, 20, 100, -1, -10, -100, 20]).cast(dtypes.bfloat16)
+      t2 = Tensor([101, -2, -11, -99, 21, 100, -1, -10, -100, 20]).cast(dtypes.bfloat16)
+      t1.realize()
+      t2.realize()
+      assert (t1 != t2).numpy().tolist() == [True, True, True, True, True, False, False, False, False, False]
+
+  def test_bf16_equal(self):
+      t1 = Tensor([100, -1, 0, -100, 20, 100, -1, 0, -100, 20]).cast(dtypes.bfloat16)
+      t2 = Tensor([100, -1, 0, -100, 20, 101, 0, 1, -99, 21]).cast(dtypes.bfloat16)
+      t1.realize()
+      t2.realize()
+      assert (t1 == t2).numpy().tolist() == [True, True, True, True, True, False, False, False, False, False]
+
+  def test_bf16_greater_than(self):
+      t1 = Tensor([100, -1, 0, -100, 20, 100, -1, 0, -100, 20]).cast(dtypes.bfloat16)
+      t2 = Tensor([99, -2, -1, -101, 19, 101, 0, 1, -99, 21,]).cast(dtypes.bfloat16)
+      t1.realize()
+      t2.realize()
+      assert (t1 > t2).numpy().tolist() == [True, True, True, True, True, False, False, False, False, False]
+
 @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16), "bfloat16 not supported")
 class TestBFloat16DType(unittest.TestCase):
   def test_bf16_to_float(self):

--- a/test/test_dtype.py
+++ b/test/test_dtype.py
@@ -156,34 +156,6 @@ class TestBFloat16(unittest.TestCase):
     assert t.dtype == dtypes.bfloat16
     np.testing.assert_allclose(t.numpy(), np.eye(3))
 
-  def test_bf16_less_than(self):
-      t1 = Tensor([100, -1, 0, -100, 20, 100, -1, 0, -100, 20]).cast(dtypes.bfloat16)
-      t2 = Tensor([101, 0, 1, -99, 21, 99, -2, -1, -101, 19]).cast(dtypes.bfloat16)
-      t1.realize()
-      t2.realize()
-      assert (t1 < t2).numpy().tolist() == [True, True, True, True, True, False, False, False, False, False]
-
-  def test_bf16_not_equal(self):
-      t1 = Tensor([100, -1, -10, -100, 20, 100, -1, -10, -100, 20]).cast(dtypes.bfloat16)
-      t2 = Tensor([101, -2, -11, -99, 21, 100, -1, -10, -100, 20]).cast(dtypes.bfloat16)
-      t1.realize()
-      t2.realize()
-      assert (t1 != t2).numpy().tolist() == [True, True, True, True, True, False, False, False, False, False]
-
-  def test_bf16_equal(self):
-      t1 = Tensor([100, -1, 0, -100, 20, 100, -1, 0, -100, 20]).cast(dtypes.bfloat16)
-      t2 = Tensor([100, -1, 0, -100, 20, 101, 0, 1, -99, 21]).cast(dtypes.bfloat16)
-      t1.realize()
-      t2.realize()
-      assert (t1 == t2).numpy().tolist() == [True, True, True, True, True, False, False, False, False, False]
-
-  def test_bf16_greater_than(self):
-      t1 = Tensor([100, -1, 0, -100, 20, 100, -1, 0, -100, 20]).cast(dtypes.bfloat16)
-      t2 = Tensor([99, -2, -1, -101, 19, 101, 0, 1, -99, 21,]).cast(dtypes.bfloat16)
-      t1.realize()
-      t2.realize()
-      assert (t1 > t2).numpy().tolist() == [True, True, True, True, True, False, False, False, False, False]
-
 @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16), "bfloat16 not supported")
 class TestBFloat16DType(unittest.TestCase):
   def test_bf16_to_float(self):

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -61,7 +61,7 @@ def universal_test(a, b, dtype, op):
   if not isinstance(op, tuple): op = (op, op)
   tensor_value = (op[0](Tensor([a], dtype=dtype), Tensor([b], dtype=dtype))).numpy()
   numpy_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)), np.array([b]).astype(_to_np_dtype(dtype)))
-  if dtype is dtypes.bfloat16: np.testing.assert_allclose(tensor_value, numpy_value, atol=1e-4, rtol=1e-2)
+  if dtype is dtypes.bfloat16: np.testing.assert_allclose(tensor_value, numpy_value, atol=1e-3, rtol=1e-2)
   elif dtype in dtypes_float: np.testing.assert_allclose(tensor_value, numpy_value, atol=1e-10)
   else: np.testing.assert_equal(tensor_value, numpy_value)
 

--- a/test/test_dtype_alu.py
+++ b/test/test_dtype_alu.py
@@ -46,6 +46,7 @@ class ht:
   float64 = strat.floats(width=64, allow_subnormal=False)
   float32 = strat.floats(width=32, allow_subnormal=False)
   float16 = strat.floats(width=16, allow_subnormal=False)
+  bfloat16 = strat.floats(width=16, allow_subnormal=False)
   uint8 = strat.integers(0, 255)
   uint16 = strat.integers(0, 65535)
   uint32 = strat.integers(0, 2**32-1)
@@ -60,7 +61,8 @@ def universal_test(a, b, dtype, op):
   if not isinstance(op, tuple): op = (op, op)
   tensor_value = (op[0](Tensor([a], dtype=dtype), Tensor([b], dtype=dtype))).numpy()
   numpy_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)), np.array([b]).astype(_to_np_dtype(dtype)))
-  if dtype in dtypes_float: np.testing.assert_allclose(tensor_value, numpy_value, atol=1e-10)
+  if dtype is dtypes.bfloat16: np.testing.assert_allclose(tensor_value, numpy_value, atol=1e-4, rtol=1e-2)
+  elif dtype in dtypes_float: np.testing.assert_allclose(tensor_value, numpy_value, atol=1e-10)
   else: np.testing.assert_equal(tensor_value, numpy_value)
 
 def universal_test_unary(a, dtype, op):
@@ -71,7 +73,7 @@ def universal_test_unary(a, dtype, op):
   run_schedule(sched)
   tensor_value = out.numpy()
   numpy_value = op[1](np.array([a]).astype(_to_np_dtype(dtype)))
-  if dtype in dtypes_float:
+  if dtype in (*dtypes_float, dtypes.bfloat16):
     np.testing.assert_allclose(tensor_value, numpy_value, atol=1e-3, rtol=1e-2)
   else: np.testing.assert_equal(tensor_value, numpy_value)
   if op[0] != Tensor.reciprocal: # reciprocal is not supported in most backends
@@ -104,12 +106,20 @@ class TestDTypeALU(unittest.TestCase):
   @given(ht.float16, ht.float16, strat.sampled_from(binary_operations))
   def test_float16(self, a, b, op): universal_test(a, b, dtypes.float16, op)
 
+  @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16, Device.DEFAULT), f"no bfloat16 on {Device.DEFAULT}")
+  @given(ht.bfloat16, ht.bfloat16, strat.sampled_from(binary_operations))
+  def test_bfloat16(self, a, b, op): universal_test(a, b, dtypes.bfloat16, op)
+
   @given(ht.float32, strat.sampled_from(unary_operations))
   def test_float32_unary(self, a, op): universal_test_unary(a, dtypes.float32, op)
 
   @unittest.skipUnless(is_dtype_supported(dtypes.float16, Device.DEFAULT), f"no float16 on {Device.DEFAULT}")
   @given(ht.float16, strat.sampled_from(unary_operations))
   def test_float16_unary(self, a, op): universal_test_unary(a, dtypes.float16, op)
+
+  @unittest.skipUnless(is_dtype_supported(dtypes.bfloat16, Device.DEFAULT), f"no bfloat16 on {Device.DEFAULT}")
+  @given(ht.bfloat16, strat.sampled_from(unary_operations))
+  def test_bfloat16_unary(self, a, op): universal_test_unary(a, dtypes.bfloat16, op)
 
   @given(ht.uint8, ht.uint8, strat.sampled_from(integer_binary_operations))
   def test_uint8(self, a, b, op): universal_test(a, b, dtypes.uint8, op)


### PR DESCRIPTION
process replay won't pass as handwritten comparison operations are removed and they are casted to float now.

Pattern Matching Enhancements:

* [`tinygrad/renderer/cstyle.py`](diffhunk://#diff-9694d15708a36a57a7e1485db60b1b4b1d2fc1e7278bc87127a73efd0bfa7dc0L393-R396): Added a new pattern matcher for `UOps.ALU` with `dtypes.bool` and simplified the existing pattern matchers for `dtypes.bfloat16`.

Kernel Rendering Adjustments:

* [`tinygrad/renderer/cstyle.py`](diffhunk://#diff-9694d15708a36a57a7e1485db60b1b4b1d2fc1e7278bc87127a73efd0bfa7dc0L418-L419): Removed the inline device operators for `hip_bfloat16` comparison operations.

Testing Enhancements:
* Modified `universal_test` and `universal_test_unary` functions to handle `bfloat16` with different tolerances (`atol=1e-3`, `rtol=1e-2`) (`test/test_dtype_alu.py`). [[1]](diffhunk://#diff-91c99ce7729ca3fbc73b86b11236a73f21937bba94d039c60955761d2d62043fL63-R65) [[2]](diffhunk://#diff-91c99ce7729ca3fbc73b86b11236a73f21937bba94d039c60955761d2d62043fL74-R76)
* Added new test cases for `bfloat16` in both binary and unary operations (`test/test_dtype_alu.py`).