### PR TITLE
refactor tc patterns for better readability [pr] 

### DIFF
--- a/tinygrad/engine/schedule.py
+++ b/tinygrad/engine/schedule.py
@@ -275,7 +275,7 @@ def create_schedule_with_vars(outs:List[LazyBuffer]) -> Tuple[List[ScheduleItem]
   # get realizes
   realizes: Dict[UOp, UOp] = {}
   graph_rewrite(big_graph, do_realize, realizes)
-  store_groups = get_realizes(children, allbufs, double_reduces, realizes, ctx)
+  store_groups = get_realizes(children, allbufs, double_reduces, realizes, ctx.buf_uops)
   # split realizes into small graphs
   graph_rewrite(big_graph, break_sched, realizes)
   sinks = [UOp.sink(*(realizes[u] for u in stores)) for stores in store_groups]


### PR DESCRIPTION
I believe this small changes makes it more readable, feel free to close if found not worth it or think it makes it less readable.

``` python
# before: for x,i in pattern, x == 0 mean take from wd and x == 1 mean take from tcd
st1_pattern=(((1,1),(1,0),(0,2),(0,3),(0,4)),((1,3),(1,5),(1,2),(0,0),(0,1),(1,4)))

# after:  for x,i in pattern, x == 1 means permute wd and tcd
st1_pattern=(((1,1),(1,0),(0,2),(0,3),(0,4)),((0,3),(0,5),(0,2),(1,0),(1,1),(0,4)))

# before 
permaxis = [...] + [y + (wd if x == 0 else tcd) for x,y in pattern_1]
           [...] + [y + (wd if x == 0 else tcd) for x,y in pattern_2] + [...]

# after
permaxis = [...] + [i + (tcd if permute else wd) for permute, i in wd_pattern]
           [...] + [i + (wd if permute else tcd) for permute, i in tcd_pattern] + [...]
```