### PR TITLE
fix `ptx` linearizer bug 2 [pr]

### DIFF
--- a/tinygrad/codegen/linearize.py
+++ b/tinygrad/codegen/linearize.py
@@ -3,7 +3,6 @@ import heapq
 from collections import defaultdict
 from dataclasses import dataclass, replace
 from tinygrad.ops import UOp, Ops, graph_rewrite, PatternMatcher, UPat, GroupOp
-from tinygrad.dtype import PtrDType
 from tinygrad.helpers import dedup, partition, all_same, flatten
 from tinygrad.spec import type_verify
 
@@ -98,7 +97,7 @@ class BlockContext:
       if u.op in {Ops.RANGE, Ops.IF}: ctx.child_ctxs[u] = _sort_ctx(ctx.block_ctxs[u] + (u,))
       elif u.op is Ops.STORE:
         # ugh, deal with non-reduce locals. probably wrong
-        if isinstance(u.src[0].dtype, PtrDType) and u.src[0].dtype.local:
+        if any(x.op is Ops.DEFINE_LOCAL for x in u.src[0].toposort):
           idx_context, store_context = ctx.last_ctx(u.src[0]), ctx.last_ctx(u.src[1])
           ctx.child_ctxs[u] = tuple([y for y in store_context if y not in idx_context and y.op is Ops.RANGE])
         else: ctx.child_ctxs[u] = ()

--- a/tinygrad/runtime/support/am/amdev.py
+++ b/tinygrad/runtime/support/am/amdev.py
@@ -45,12 +45,11 @@ class AMFirmware:
     self.smu_psp_desc = self.desc(blob, hdr.header.ucode_array_offset_bytes, hdr.header.ucode_size_bytes, am.GFX_FW_TYPE_SMU)
 
     # SDMA firmware
-    blob, hdr = self.load_fw(f"sdma_{fmt_ver(am.SDMA0_HWIP)}.bin", am.struct_sdma_firmware_header_v3_0)
+    blob, hdr, hdr_v3 = self.load_fw(f"sdma_{fmt_ver(am.SDMA0_HWIP)}.bin", am.struct_sdma_firmware_header_v2_0, am.struct_sdma_firmware_header_v3_0)
     if hdr.header.header_version_major < 3:
-      blob, hdr = self.load_fw(f"sdma_{fmt_ver(am.SDMA0_HWIP)}.bin", am.struct_sdma_firmware_header_v2_0)
       self.descs += [self.desc(blob, hdr.ctl_ucode_offset, hdr.ctl_ucode_size_bytes, am.GFX_FW_TYPE_SDMA_UCODE_TH1)]
       self.descs += [self.desc(blob, hdr.header.ucode_array_offset_bytes, hdr.ctx_ucode_size_bytes, am.GFX_FW_TYPE_SDMA_UCODE_TH0)]
-    else: self.descs += [self.desc(blob, hdr.header.ucode_array_offset_bytes, hdr.ucode_size_bytes, am.GFX_FW_TYPE_SDMA_UCODE_TH0)]
+    else: self.descs += [self.desc(blob, hdr_v3.header.ucode_array_offset_bytes, hdr_v3.ucode_size_bytes, am.GFX_FW_TYPE_SDMA_UCODE_TH0)]
 
     # PFP, ME, MEC firmware
     for (fw_name, fw_cnt) in [('PFP', 2), ('ME', 2), ('MEC', 4)]:


### PR DESCRIPTION
The root cause for this bug is that a special workaround within the linearizer for handling non-reduce locals doesn't function correctly following the pointer arithmetic rewrite in the PTX backend.

This was because it was relying on the store first source to check for local buffer, but with pointer arithmetic, its not longer the case, the first source usually is an Ops.ADD or Ops.CAST, thus not falling into special workaround check and not propagating correctly the context.

Now, instead of only checking the first source for local buffer, it checks for a local buffer in the toposort of the first source.

I benchmarked the change with `test/external/external_benchmark_schedule.py`
ptx_bug_2: `Mean: 550.43 ms  |  Std: 9.35 ms  |  Min: 542.32 ms  |  Max: 585.28 ms  (N=20)`
master (b35f94b6): `Mean: 543.89 ms  |  Std: 8.31 ms  |  Min: 536.69 ms  |  Max: 578.06 ms  (N=20)`

benchmark performed in tiny19; command to reproduce:
```
python - <<'PY'
import os, re, subprocess, statistics
N = 20
pat = re.compile(r'model linearize in\s+([0-9.]+)\s+ms')
base_env = os.environ.copy()
base_env["NULL"] = "1"

times = [
    float(pat.search(
        subprocess.check_output(
            ['python', 'test/external/external_benchmark_schedule.py'],
            text=True, env=base_env
        )
    ).group(1))
    for _ in range(N)
]

print(f"Mean: {statistics.mean(times):.2f} ms  |  "
      f"Std: {statistics.stdev(times):.2f} ms  |  "
      f"Min: {min(times):.2f} ms  |  "
      f"Max: {max(times):.2f} ms  (N={N})")
print("Values:", ", ".join(f"{t:.2f}" for t in times))
PY
```

This fixes also TC=3 emulation for ptx that was broken