### PR TITLE
use modified_ast for ProgramSpec

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -44,7 +44,7 @@ def get_program(ast:UOp, renderer:Renderer) -> ProgramSpec:
   if DEBUG >= 6: print_uops(uops)
   src = renderer.render(uops)
 
-  return ProgramSpec(uops[-1].arg.name, src, renderer.device, ast, uops,
+  return ProgramSpec(uops[-1].arg.name, src, renderer.device, modified_ast, uops,
                      global_size=[1,1,1] if renderer.has_local else None, local_size=[1,1,1] if renderer.has_local else None)
 
 # **************** Runners ****************


### PR DESCRIPTION
Is there any particular reason we use the original ast for `ProgramSpec`?

I came across this while refactoring some calls to `linearize` method from `kernel` in the tests. I realized that if we use the original ast for the `ProgramSpec` and apply some opts through the new `opts_to_apply` api, the original ast won't correctly track the `applied_opts`. If we want the state to live in the uops, we need to use `modified_ast` for `ProgramSpec`.

Notice that in order to print the `applied_opts`, `modified_ast` is used in line 39.

https://github.com/ignaciosica/tinygrad/blob/cf60ccac6a44002c493c60739b4c4d44f801c50e/tinygrad/engine/realize.py#L17-L48

I'm asking this question and not considering this bug because the original ast was also used for ProgramSpec before all the refactors that have been taking place lately, so maybe there is a reason behind it.