### PR TITLE
replace ast arg on get_optimized_ast call [pr]

### DIFF
--- a/tinygrad/engine/realize.py
+++ b/tinygrad/engine/realize.py
@@ -27,7 +27,13 @@ def get_program(ast:UOp, renderer:Renderer) -> ProgramSpec:
   """
 
   if getenv("VIZ"): graph_rewrite(ast, PatternMatcher([]), name="View Base AST")
-  modified_ast = get_optimized_ast(ast, renderer) if ast.arg is None or ast.arg.opts_to_apply is not None else ast
+
+  if ast.arg is None or ast.arg.opts_to_apply is not None:
+    modified_ast = get_optimized_ast(ast, renderer)
+    ast = ast.replace(arg=modified_ast.arg)
+  else:
+    modified_ast = ast
+
   if __debug__: type_verify(list(modified_ast.toposort()))
 
   # linearize


### PR DESCRIPTION
It is either this solution or adding back applied_opts to ProgramSpec, otherwise the applied opts are not going to be tracked correctly after get_optimized_ast call.

I opted for this approach to keep the state in the uops.