### PR TITLE
yellow before red 4 [pr]

### DIFF
--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -207,6 +207,7 @@ class Kernel:
     self.axes["global"] -= sum(all_ones[:local_offset])
     self.axes["local"] -= sum(all_ones[local_offset:reduce_offset])
     self.axes["reduce"] -= sum(all_ones[reduce_offset:upcast_offset])
+    self.axes["upcast"] -= sum(all_ones[upcast_offset:])
     self.reshape_and_permute(lambda shape: [x for i,x in enumerate(shape) if not all_ones[i]], None)
     return any(all_ones)
 


### PR DESCRIPTION
SUMMARY: use OrderedDict to keep track of axes offsets and counts

### yellow before red

this is the beginning of the refactor towards yellow before red. This will increase lines in the short term as I'm trying not to early optimize and keep the prs as small and readable as possible. I think this whole refactor will make `kernel.py` more readable and maintainable for the future.

**the challenge**

moving upcast dimensions before reduce dimensions introduces 3 major changes in how axes are organized:

1. upcast are moved before reduce (yellow before red)
2. group and reduce are split
3. upcast and unroll are split

currently, identifying if an axis is global, local, reduce, group or upcast is calculated through offset and counts. `first_reduce` is the base for most calculations in conjunction with `local_dims`(count), `upcasted`(count) and `group_for_reduce`(count) (`first_reduce` is obtained through checking sts for difference).

some examples:
  `global_dims = first_reduce - local_dims`
  `first_local = global_dims`
  `first_upcast = shape_len - upcasted`

I initially tried to stick to current paradigm, but quickly realized that this 3 changes make sticking to the current way of calculating offsets and count verbose, complicated and error-prone.

in order to workaround this issue, I propose this new way of keeping track of axes and their offsets.

``` python
self.axes = OrderedDict((("global", g), ("local", l), ("reduce", r), ("upcast", u)))
```

with this new approach, calculating offsets becomes trivial, as it just accumulating over values. 

``` python
self.get_offset(axis_name) # offset
self.axes[axis_name] # count
```

offsets and counts are now exposed through this simpler api, instead of the uneven first_reduce (for reduce and group) / first_upcast (for upcast) / global_dims (for locals), ...

let me know if you like the direction of this refactor

---

after yellow before red, axes will be configured in the following way.

``` python
self.axes = OrderedDict((
  ("global", gl), 
  ("local", l), 
  ("group", gr), 
  ("upcast", up), 
  ("reduce", r), 
  ("unroll", un),
))
```

---

NOTE: keeping as a draft for now as I didn't identified yet what is breaking pr

