### PR TITLE
rename info to kernel_info [pr]

### DIFF
--- a/test/unit/test_linearizer_rewrite.py
+++ b/test/unit/test_linearizer_rewrite.py
@@ -42,5 +42,11 @@ class TestLinearizerRewrite(unittest.TestCase):
     prg = get_program(ast.replace(arg=KernelInfo(name="custom")), Device["CPU"].renderer)
     self.assertEqual(prg.name, "custom")
 
+    opts = (Opt(OptOps.UPCAST, 0, 2),)
+    prg = get_program(ast.replace(arg=KernelInfo(opts_to_apply=opts)), Device["CPU"].renderer)
+    assert prg.uops is not None and prg.uops[-1].arg is not None and isinstance(prg.uops[-1].arg, KernelInfo), "expected uops and kernelinfo"
+    assert prg.applied_opts == opts, f"expected opts to be {opts}, got {prg.applied_opts}"
+    assert prg.uops[-1].arg.opts_to_apply is None, f"expected opts_to_apply to be None, got {prg.uops[-1].arg.opts_to_apply}"
+
 if __name__ == '__main__':
   unittest.main()

--- a/tinygrad/opt/kernel.py
+++ b/tinygrad/opt/kernel.py
@@ -35,7 +35,7 @@ class Kernel:
   def __init__(self, ast:UOp, opts:Optional[Renderer]=None):
     assert ast.op is Ops.SINK, ast.op
     self.ast = ast
-    self.info: KernelInfo = self.ast.arg if self.ast.arg is not None else KernelInfo()
+    self.kernel_info: KernelInfo = self.ast.arg if self.ast.arg is not None else KernelInfo()
 
     self.opts = opts if opts is not None else Device[Device.DEFAULT].renderer
     # verify AST matches the spec
@@ -85,12 +85,12 @@ class Kernel:
     ret.sts = self.sts[:]
 
     # parameters for optimizations
-    ret.info, ret.group_for_reduces = self.info, self.group_for_reduces
+    ret.kernel_info, ret.group_for_reduces = self.kernel_info, self.group_for_reduces
     ret.tensor_core, ret.tensor_core_opts, ret.use_tensor_cores = self.tensor_core, self.tensor_core_opts, self.use_tensor_cores
 
     return ret
 
-  def update_info(self, **updates): self.info = replace(self.info, **updates)
+  def update_info(self, **updates): self.kernel_info = replace(self.kernel_info, **updates)
 
   @property
   def membufs(self) -> list[UOp]: return dedup([x.src[0].base for x in self.bufs if x.op in {Ops.LOAD, Ops.STORE}])
@@ -127,16 +127,16 @@ class Kernel:
   def global_dims(self) -> int: return self.first_reduce-self.local_dims
 
   @property
-  def local_dims(self) -> int: return self.info.local_dims
+  def local_dims(self) -> int: return self.kernel_info.local_dims
 
   @property
-  def upcasted(self) -> int: return self.info.upcasted
+  def upcasted(self) -> int: return self.kernel_info.upcasted
 
   @property
-  def dont_use_locals(self) -> bool: return self.info.dont_use_locals
+  def dont_use_locals(self) -> bool: return self.kernel_info.dont_use_locals
 
   @property
-  def applied_opts(self) -> list[Opt]: return list(self.info.applied_opts)
+  def applied_opts(self) -> list[Opt]: return list(self.kernel_info.applied_opts)
 
   # there's eight chunks of the shape
   # blue   -- global dims
@@ -178,7 +178,7 @@ class Kernel:
   # drops the final dimension
   def upcast(self):
     check(self.full_shape[-1] != 1, "can't upcast a dimension with size 1")
-    self.update_info(upcasted=self.info.upcasted + 1)
+    self.update_info(upcasted=self.kernel_info.upcasted + 1)
 
   # axis : the axis to pull from
   # amount : the amount to take
@@ -354,7 +354,7 @@ class Kernel:
       check(0 <= (tc_opt:=cast(tuple, opt.arg)[1]) <= 2, "tensor core opts must have valid tc_opt")
       check(0 < (use_tensor_cores:=cast(tuple, opt.arg)[2]) <= 2, "use_tensor_cores value is not valid")
       check(self._apply_tc_opt(use_tensor_cores, cast(int, opt.axis), tc_select, tc_opt), "no tensor core available")
-      self.update_info(applied_opts=self.info.applied_opts + (opt,))
+      self.update_info(applied_opts=self.kernel_info.applied_opts + (opt,))
       return
 
     axis = self.real_axis(opt)
@@ -382,7 +382,7 @@ class Kernel:
       check(self.opts.has_local, "target does not support local")
       check(axis < self.global_dims, "local is for globals")
       self.shift_to(axis, amt, insert_before=self.first_reduce)
-      self.update_info(local_dims=self.info.local_dims + 1)
+      self.update_info(local_dims=self.kernel_info.local_dims + 1)
     elif opt.op in {OptOps.GROUP, OptOps.GROUPTOP}:   # green
       check(self.opts.has_local and self.opts.has_shared, "target does not support local or shared mem")
       check(self.first_reduce + self.group_for_reduces <= axis < self.first_upcast, "must be reduce axis to group")
@@ -431,7 +431,7 @@ class Kernel:
           padded = True
       check(padded, "nothing was padded")
 
-    if append_opt: self.update_info(applied_opts=self.info.applied_opts + (opt,))
+    if append_opt: self.update_info(applied_opts=self.kernel_info.applied_opts + (opt,))
     if self.simplify_ones() and self.tensor_core_opts:
       self.tensor_core_opts.fix_axes(axis) # fix up axes in TC opts if required after simplify_ones()
 
@@ -466,8 +466,9 @@ class Kernel:
         return ret.replace(src=(ret.src[0].replace(arg=st),)+ret.src[1:])
       if op.op is Ops.SINK:
         # NOTE: should group_for_reduces be added to the local_dims?
-        return ret.replace(arg=replace(self.info, name=ret.arg.name if ret.arg is not None else self.name if name_override is None else name_override,
-          global_dims=self.global_dims if self.opts.has_local else 0, local_dims=self.local_dims + self.group_for_reduces, opts_to_apply=None))
+        return ret.replace(arg = KernelInfo(ret.arg.name if ret.arg is not None else self.name if name_override is None else name_override,
+                                            self.global_dims if self.opts.has_local else 0, self.local_dims + self.group_for_reduces,
+                                            self.upcasted, self.dont_use_locals, tuple(self.applied_opts)))
       if op.op is Ops.REDUCE_AXIS:
         reduce_idx = len(self.bufs) + self.reduceops.index(op) * 2
 


### PR DESCRIPTION
Renaming `info` to `kernel_info` so that if in the future kernel_info is added to the ProgramSpec api, it can be consistent and more clear.

Moved back to init KernelInfo in get_optimized_ast based on qaz feedback

Also added regression test